### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ easily self-host the front-end code for connecting to your WebKit devtools agent
 
 ## Installation
 
-`node install -g webkit-devtools-agent-frontend`
+`npm install -g webkit-devtools-agent-frontend`
 
 In the application you want to profile, install and run [Node WebKit Agent](//github.com/c4milo/node-webkit-agent).
 


### PR DESCRIPTION
- `npm install` instead of `node install`

Small typo I noticed.  For some reason I typed "node install" without thinking (just copying from the readme) and came back to the console a few minutes later wondering why I had typed "node."
